### PR TITLE
Fix a colon being added after youtube mentions

### DIFF
--- a/gthx.py
+++ b/gthx.py
@@ -662,7 +662,7 @@ class Gthx(irc.IRCClient):
                     titleQuery.addCallback(queryResponse)
                 else:
                     print "Already have a title for item %s: %s" % (youtubeId, title)
-                    reply = 'http://www.youtube.com/watch?v=:%s => %s => %s IRC mentions' % (youtubeId, title, refs)
+                    reply = 'http://www.youtube.com/watch?v=%s => %s => %s IRC mentions' % (youtubeId, title, refs)
                     self.msg(replyChannel, reply)
                 
     def action(self, sender, channel, message):


### PR DESCRIPTION
With youtube links upon the first mention Gthx correctly links the youtube URL back into chat with title, However upon any further mentions of the same youtube link a colon ':' was being added between the youtube.com/watch?v= and the youtubeID. Removed this errant Colon.